### PR TITLE
Parse tsconfig.json with typescript.

### DIFF
--- a/.changeset/good-fireants-yawn.md
+++ b/.changeset/good-fireants-yawn.md
@@ -1,0 +1,5 @@
+---
+"tsmpkg": minor
+---
+
+Parse tsconfig.json with packages's typescript.

--- a/packages/tsmpkg/package.json
+++ b/packages/tsmpkg/package.json
@@ -33,9 +33,7 @@
     "@pnpm/find-workspace-dir": "^6.0.2",
     "@pnpm/find-workspace-packages": "^6.0.9",
     "chalk": "^5.3.0",
-    "fs-extra": "^11.1.1",
-    "tsconfig": "^7.0.0",
-    "types-tsconfig": "^2.0.2"
+    "fs-extra": "^11.1.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/tsmpkg/src/check/validateTsConfigJson.ts
+++ b/packages/tsmpkg/src/check/validateTsConfigJson.ts
@@ -14,7 +14,16 @@ export const validateTsConfigJson = async (dir: string) => {
     return displayTsconfigValidationErrors(errors);
   } catch (err) {
     if (err instanceof InvalidTsConfigError) {
-      return displayTsconfigValidationErrors([err.message]);
+      const errors = [err.message];
+      let cause = err.cause;
+      while (cause instanceof Error) {
+        errors.push(cause.message);
+        cause = cause.cause;
+      }
+      if (cause) {
+        errors.push(String(cause));
+      }
+      return displayTsconfigValidationErrors(errors);
     }
     throw err;
   }

--- a/packages/tsmpkg/tsconfig.json
+++ b/packages/tsmpkg/tsconfig.json
@@ -15,7 +15,7 @@
     /* Type Checking */
     "strict": true /* Enable all strict type-checking options. */,
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-    "lib": ["es2020"]
+    "lib": ["es2022"]
   },
   "include": ["./src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,12 +89,6 @@ importers:
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1
-      tsconfig:
-        specifier: ^7.0.0
-        version: 7.0.0
-      types-tsconfig:
-        specifier: ^2.0.2
-        version: 2.0.2
     devDependencies:
       '@types/fs-extra':
         specifier: ^11.0.3
@@ -1159,14 +1153,6 @@ packages:
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==}
     dependencies:
       '@types/node': 20.8.10
-    dev: false
-
-  /@types/strip-bom@3.0.0:
-    resolution: {integrity: sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ==}
-    dev: false
-
-  /@types/strip-json-comments@0.0.30:
-    resolution: {integrity: sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==}
     dev: false
 
   /@typescript-eslint/eslint-plugin@6.9.1(@typescript-eslint/parser@6.9.1)(eslint@8.52.0)(typescript@5.2.2):
@@ -3898,6 +3884,7 @@ packages:
   /strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+    dev: true
 
   /strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -3918,11 +3905,6 @@ packages:
     dependencies:
       min-indent: 1.0.1
     dev: true
-
-  /strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
 
   /strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -4059,15 +4041,6 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /tsconfig@7.0.0:
-    resolution: {integrity: sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==}
-    dependencies:
-      '@types/strip-bom': 3.0.0
-      '@types/strip-json-comments': 0.0.30
-      strip-bom: 3.0.0
-      strip-json-comments: 2.0.1
-    dev: false
-
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
     dev: false
@@ -4152,11 +4125,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /type-fest@3.13.1:
-    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
-    engines: {node: '>=14.16'}
-    dev: false
-
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
@@ -4194,14 +4162,6 @@ packages:
       for-each: 0.3.3
       is-typed-array: 1.1.12
     dev: true
-
-  /types-tsconfig@2.0.2:
-    resolution: {integrity: sha512-La7awO5Ge1y9Ew/puVOtm7uZW9hLAGCTSY1F/7guQ7t6oaOvPmeKOcfdVVctjeVj+5S2J6esH8qwVW0eI7rQyQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    dependencies:
-      type-fest: 3.13.1
-      zod: 3.21.4
-    dev: false
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
@@ -4595,7 +4555,3 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
-
-  /zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
-    dev: false


### PR DESCRIPTION
Replace `tsconfig` and `types-tsconfig` packages which can get out of date.

I tried to use the typescript package from the search directory, which might be a bit extra, as well as using `ts.findConfig()`, which will e.g. find `repo/tsconfig.json` if `repo/packages/some-package/tsconfig.json` is missing, but I *think* that's what `tsconfig.read` did.