### PR TITLE
Nested entry

### DIFF
--- a/.changeset/cuddly-frogs-think.md
+++ b/.changeset/cuddly-frogs-think.md
@@ -1,0 +1,5 @@
+---
+"tsmpkg": patch
+---
+
+Fix issue where nested tsup.entry key would cause tsmpkg dev to fail.

--- a/.changeset/old-wolves-exist.md
+++ b/.changeset/old-wolves-exist.md
@@ -1,0 +1,6 @@
+---
+"test-pkg-cjs": patch
+"test-pkg": patch
+---
+
+Reproduce nested entry error.

--- a/.idea/tsmpkg.iml
+++ b/.idea/tsmpkg.iml
@@ -2,10 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
-      <excludeFolder url="file://$MODULE_DIR$/temp" />
-      <excludeFolder url="file://$MODULE_DIR$/tmp" />
-      <excludeFolder url="file://$MODULE_DIR$/dist" />
+      <excludePattern pattern="dist" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/packages/test-pkg-cjs/package.json
+++ b/packages/test-pkg-cjs/package.json
@@ -18,7 +18,7 @@
   "tsup": {
     "entry": {
       "index": "./src/index.ts",
-      "schemas": "./src/schemas/index.ts"
+      "schemas/index": "./src/schemas/index.ts"
     },
     "clean": true,
     "format": [

--- a/packages/test-pkg/package.json
+++ b/packages/test-pkg/package.json
@@ -21,7 +21,7 @@
   "tsup": {
     "entry": {
       "index": "./src/index.ts",
-      "schemas": "./src/schemas/index.ts"
+      "schemas/index": "./src/schemas/index.ts"
     },
     "clean": true,
     "format": [

--- a/packages/tsmpkg/src/dev/dev.ts
+++ b/packages/tsmpkg/src/dev/dev.ts
@@ -62,10 +62,12 @@ export const devPkg = async (dir: string, options: DevOptions) => {
   const entryPoints = getEntryPoints(pkg.tsup);
 
   const makeLinks = async (name: string, target: string, ext: Extension) => {
-    await fs.symlink(
-      path.join(dir, target),
-      path.join(distPath, `${name}${ext}`),
-    );
+    const targetPath = path.join(dir, target);
+    const linkPath = path.join(distPath, `${name}${ext}`);
+    // tsup.entry keys may contain subdirectories, so we need to ensure the
+    // parent directory exists before creating the symlink.
+    await fs.mkdir(path.dirname(linkPath), { recursive: true });
+    await fs.symlink(targetPath, linkPath);
 
     const dtsExt = dtsExtensionFromExtension(ext);
     await fs.writeFile(


### PR DESCRIPTION
Fixes an issue I hit while updating interact repo to 0.2.0, though I don't know why it wasn't hit before (maybe tsup always ran?).

Dunno why it wasn't being hit before, but if you have a `tsup.entry` key with a subdir, then `fs.symlink` is trying to create a link in a non-existent subdir of `dist`.